### PR TITLE
"アプリケーションを起動する"のリンクテキストを修正する

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@
 - [tiscon5-startup-guide](https://github.com/tiscon/tiscon5-startup-guide)
 
 ## アプリケーションを起動する
-- [自分のPCでアプリを動かす(Windows)](https://github.com/tiscon/tiscon5-startup-guide)
+- [自分のPCでアプリを動かす](https://github.com/tiscon/tiscon5-startup-guide)
 
 # 参考
 


### PR DESCRIPTION
## what
ガイド `README.md` の「アプリケーションを動かす」についてwindowsに限定されているように見えるが、リンク先のドキュメントを見るとmacの手順も同様のguideを参照するようにみえる

## why
- macユーザが混乱しないようにするため

## remarks
- ❓ `自分のPCでアプリを動かす` リンクを押すとstartup-guideに遷移する挙動は想定通りか
    - ページの誤りや、ハッシュのつけ忘れがないか